### PR TITLE
Add Newsletter microservice implementing newsletter-technical-design.md

### DIFF
--- a/OriginHairCollective.sln
+++ b/OriginHairCollective.sln
@@ -85,6 +85,16 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OriginHairCollective.Chat.A
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OriginHairCollective.Chat.Api", "src\Services\Chat\OriginHairCollective.Chat.Api\OriginHairCollective.Chat.Api.csproj", "{99AC50A8-4F73-4592-9FD4-DE9DC741E1B7}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Newsletter", "Newsletter", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OriginHairCollective.Newsletter.Core", "src\Services\Newsletter\OriginHairCollective.Newsletter.Core\OriginHairCollective.Newsletter.Core.csproj", "{B1C2D3E4-F5A6-7890-BCDE-F12345678901}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OriginHairCollective.Newsletter.Infrastructure", "src\Services\Newsletter\OriginHairCollective.Newsletter.Infrastructure\OriginHairCollective.Newsletter.Infrastructure.csproj", "{C1D2E3F4-A5B6-7890-CDEF-123456789012}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OriginHairCollective.Newsletter.Application", "src\Services\Newsletter\OriginHairCollective.Newsletter.Application\OriginHairCollective.Newsletter.Application.csproj", "{D1E2F3A4-B5C6-7890-DEFA-234567890123}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OriginHairCollective.Newsletter.Api", "src\Services\Newsletter\OriginHairCollective.Newsletter.Api\OriginHairCollective.Newsletter.Api.csproj", "{E1F2A3B4-C5D6-7890-EFAB-345678901234}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -527,6 +537,54 @@ Global
 		{99AC50A8-4F73-4592-9FD4-DE9DC741E1B7}.Release|x64.Build.0 = Release|Any CPU
 		{99AC50A8-4F73-4592-9FD4-DE9DC741E1B7}.Release|x86.ActiveCfg = Release|Any CPU
 		{99AC50A8-4F73-4592-9FD4-DE9DC741E1B7}.Release|x86.Build.0 = Release|Any CPU
+		{B1C2D3E4-F5A6-7890-BCDE-F12345678901}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1C2D3E4-F5A6-7890-BCDE-F12345678901}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1C2D3E4-F5A6-7890-BCDE-F12345678901}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B1C2D3E4-F5A6-7890-BCDE-F12345678901}.Debug|x64.Build.0 = Debug|Any CPU
+		{B1C2D3E4-F5A6-7890-BCDE-F12345678901}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B1C2D3E4-F5A6-7890-BCDE-F12345678901}.Debug|x86.Build.0 = Debug|Any CPU
+		{B1C2D3E4-F5A6-7890-BCDE-F12345678901}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1C2D3E4-F5A6-7890-BCDE-F12345678901}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1C2D3E4-F5A6-7890-BCDE-F12345678901}.Release|x64.ActiveCfg = Release|Any CPU
+		{B1C2D3E4-F5A6-7890-BCDE-F12345678901}.Release|x64.Build.0 = Release|Any CPU
+		{B1C2D3E4-F5A6-7890-BCDE-F12345678901}.Release|x86.ActiveCfg = Release|Any CPU
+		{B1C2D3E4-F5A6-7890-BCDE-F12345678901}.Release|x86.Build.0 = Release|Any CPU
+		{C1D2E3F4-A5B6-7890-CDEF-123456789012}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C1D2E3F4-A5B6-7890-CDEF-123456789012}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C1D2E3F4-A5B6-7890-CDEF-123456789012}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C1D2E3F4-A5B6-7890-CDEF-123456789012}.Debug|x64.Build.0 = Debug|Any CPU
+		{C1D2E3F4-A5B6-7890-CDEF-123456789012}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C1D2E3F4-A5B6-7890-CDEF-123456789012}.Debug|x86.Build.0 = Debug|Any CPU
+		{C1D2E3F4-A5B6-7890-CDEF-123456789012}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C1D2E3F4-A5B6-7890-CDEF-123456789012}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C1D2E3F4-A5B6-7890-CDEF-123456789012}.Release|x64.ActiveCfg = Release|Any CPU
+		{C1D2E3F4-A5B6-7890-CDEF-123456789012}.Release|x64.Build.0 = Release|Any CPU
+		{C1D2E3F4-A5B6-7890-CDEF-123456789012}.Release|x86.ActiveCfg = Release|Any CPU
+		{C1D2E3F4-A5B6-7890-CDEF-123456789012}.Release|x86.Build.0 = Release|Any CPU
+		{D1E2F3A4-B5C6-7890-DEFA-234567890123}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D1E2F3A4-B5C6-7890-DEFA-234567890123}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D1E2F3A4-B5C6-7890-DEFA-234567890123}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D1E2F3A4-B5C6-7890-DEFA-234567890123}.Debug|x64.Build.0 = Debug|Any CPU
+		{D1E2F3A4-B5C6-7890-DEFA-234567890123}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D1E2F3A4-B5C6-7890-DEFA-234567890123}.Debug|x86.Build.0 = Debug|Any CPU
+		{D1E2F3A4-B5C6-7890-DEFA-234567890123}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D1E2F3A4-B5C6-7890-DEFA-234567890123}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D1E2F3A4-B5C6-7890-DEFA-234567890123}.Release|x64.ActiveCfg = Release|Any CPU
+		{D1E2F3A4-B5C6-7890-DEFA-234567890123}.Release|x64.Build.0 = Release|Any CPU
+		{D1E2F3A4-B5C6-7890-DEFA-234567890123}.Release|x86.ActiveCfg = Release|Any CPU
+		{D1E2F3A4-B5C6-7890-DEFA-234567890123}.Release|x86.Build.0 = Release|Any CPU
+		{E1F2A3B4-C5D6-7890-EFAB-345678901234}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E1F2A3B4-C5D6-7890-EFAB-345678901234}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E1F2A3B4-C5D6-7890-EFAB-345678901234}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E1F2A3B4-C5D6-7890-EFAB-345678901234}.Debug|x64.Build.0 = Debug|Any CPU
+		{E1F2A3B4-C5D6-7890-EFAB-345678901234}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E1F2A3B4-C5D6-7890-EFAB-345678901234}.Debug|x86.Build.0 = Debug|Any CPU
+		{E1F2A3B4-C5D6-7890-EFAB-345678901234}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E1F2A3B4-C5D6-7890-EFAB-345678901234}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E1F2A3B4-C5D6-7890-EFAB-345678901234}.Release|x64.ActiveCfg = Release|Any CPU
+		{E1F2A3B4-C5D6-7890-EFAB-345678901234}.Release|x64.Build.0 = Release|Any CPU
+		{E1F2A3B4-C5D6-7890-EFAB-345678901234}.Release|x86.ActiveCfg = Release|Any CPU
+		{E1F2A3B4-C5D6-7890-EFAB-345678901234}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -572,5 +630,10 @@ Global
 		{A9051CB2-CDE4-473C-B27E-331790BF2675} = {2BBB9C17-E68D-4DF0-859D-D6C60C4339F3}
 		{4E120D1F-B436-4E7D-AF3F-F47B7BB3A59C} = {2BBB9C17-E68D-4DF0-859D-D6C60C4339F3}
 		{99AC50A8-4F73-4592-9FD4-DE9DC741E1B7} = {2BBB9C17-E68D-4DF0-859D-D6C60C4339F3}
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890} = {984BB9B3-3FA3-BE33-9484-CAC21695A33C}
+		{B1C2D3E4-F5A6-7890-BCDE-F12345678901} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
+		{C1D2E3F4-A5B6-7890-CDEF-123456789012} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
+		{D1E2F3A4-B5C6-7890-DEFA-234567890123} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
+		{E1F2A3B4-C5D6-7890-EFAB-345678901234} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 	EndGlobalSection
 EndGlobal

--- a/src/Aspire/OriginHairCollective.AppHost/OriginHairCollective.AppHost.csproj
+++ b/src/Aspire/OriginHairCollective.AppHost/OriginHairCollective.AppHost.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\..\Services\Notification\OriginHairCollective.Notification.Api\OriginHairCollective.Notification.Api.csproj" />
     <ProjectReference Include="..\..\Services\Identity\OriginHairCollective.Identity.Api\OriginHairCollective.Identity.Api.csproj" />
     <ProjectReference Include="..\..\Services\Chat\OriginHairCollective.Chat.Api\OriginHairCollective.Chat.Api.csproj" />
+    <ProjectReference Include="..\..\Services\Newsletter\OriginHairCollective.Newsletter.Api\OriginHairCollective.Newsletter.Api.csproj" />
     <ProjectReference Include="..\..\Gateway\OriginHairCollective.ApiGateway\OriginHairCollective.ApiGateway.csproj" />
   </ItemGroup>
 

--- a/src/Aspire/OriginHairCollective.AppHost/Program.cs
+++ b/src/Aspire/OriginHairCollective.AppHost/Program.cs
@@ -25,6 +25,9 @@ var identityApi = builder.AddProject<Projects.OriginHairCollective_Identity_Api>
 var chatApi = builder.AddProject<Projects.OriginHairCollective_Chat_Api>("chat-api")
     .WithReference(messaging);
 
+var newsletterApi = builder.AddProject<Projects.OriginHairCollective_Newsletter_Api>("newsletter-api")
+    .WithReference(messaging);
+
 var apiGateway = builder.AddProject<Projects.OriginHairCollective_ApiGateway>("api-gateway")
     .WithReference(catalogApi)
     .WithReference(inquiryApi)
@@ -33,7 +36,8 @@ var apiGateway = builder.AddProject<Projects.OriginHairCollective_ApiGateway>("a
     .WithReference(contentApi)
     .WithReference(notificationApi)
     .WithReference(identityApi)
-    .WithReference(chatApi);
+    .WithReference(chatApi)
+    .WithReference(newsletterApi);
 
 builder.AddNpmApp("angular", "../../Web/origin-hair-collective-web", "start")
     .WithReference(apiGateway)

--- a/src/Gateway/OriginHairCollective.ApiGateway/appsettings.json
+++ b/src/Gateway/OriginHairCollective.ApiGateway/appsettings.json
@@ -86,6 +86,15 @@
         "Match": {
           "Path": "/hubs/chat/{**catch-all}"
         }
+      },
+      "newsletters-route": {
+        "ClusterId": "newsletters-cluster",
+        "Match": {
+          "Path": "/api/newsletters/{**catch-all}"
+        },
+        "Transforms": [
+          { "PathRemovePrefix": "/api/newsletters" }
+        ]
       }
     },
     "Clusters": {
@@ -142,6 +151,13 @@
         "Destinations": {
           "chat-api": {
             "Address": "http://chat-api"
+          }
+        }
+      },
+      "newsletters-cluster": {
+        "Destinations": {
+          "newsletter-api": {
+            "Address": "http://newsletter-api"
           }
         }
       }

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Api/BackgroundServices/CampaignSchedulerService.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Api/BackgroundServices/CampaignSchedulerService.cs
@@ -1,0 +1,69 @@
+using OriginHairCollective.Newsletter.Core.Entities;
+using OriginHairCollective.Newsletter.Core.Enums;
+using OriginHairCollective.Newsletter.Core.Interfaces;
+using OriginHairCollective.Shared.Contracts;
+using MassTransit;
+
+namespace OriginHairCollective.Newsletter.Api.BackgroundServices;
+
+public sealed class CampaignSchedulerService(
+    IServiceScopeFactory scopeFactory,
+    IConfiguration configuration,
+    ILogger<CampaignSchedulerService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var intervalMinutes = int.Parse(configuration["Newsletter:SchedulerIntervalMinutes"] ?? "1");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await ProcessScheduledCampaignsAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error processing scheduled campaigns");
+            }
+
+            await Task.Delay(TimeSpan.FromMinutes(intervalMinutes), stoppingToken);
+        }
+    }
+
+    private async Task ProcessScheduledCampaignsAsync(CancellationToken ct)
+    {
+        using var scope = scopeFactory.CreateScope();
+        var campaignRepository = scope.ServiceProvider.GetRequiredService<ICampaignRepository>();
+        var subscriberRepository = scope.ServiceProvider.GetRequiredService<ISubscriberRepository>();
+        var recipientRepository = scope.ServiceProvider.GetRequiredService<ICampaignRecipientRepository>();
+        var publishEndpoint = scope.ServiceProvider.GetRequiredService<IPublishEndpoint>();
+
+        var dueCampaigns = await campaignRepository.GetScheduledDueAsync(DateTime.UtcNow, ct);
+
+        foreach (var campaign in dueCampaigns)
+        {
+            logger.LogInformation("Processing scheduled campaign {CampaignId}: {Subject}",
+                campaign.Id, campaign.Subject);
+
+            var subscribers = await subscriberRepository.GetActiveByTagAsync(campaign.TargetTag, ct);
+
+            var recipients = subscribers.Select(s => new CampaignRecipient
+            {
+                Id = Guid.NewGuid(),
+                CampaignId = campaign.Id,
+                SubscriberId = s.Id,
+                Email = s.Email,
+                Status = DeliveryStatus.Queued
+            }).ToList();
+
+            await recipientRepository.AddBatchAsync(recipients, ct);
+
+            campaign.Status = CampaignStatus.Sending;
+            campaign.TotalRecipients = recipients.Count;
+            await campaignRepository.UpdateAsync(campaign, ct);
+
+            await publishEndpoint.Publish(new CampaignSendRequestedEvent(
+                campaign.Id, campaign.Subject, recipients.Count, DateTime.UtcNow), ct);
+        }
+    }
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Api/Controllers/AdminNewsletterController.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Api/Controllers/AdminNewsletterController.cs
@@ -1,0 +1,129 @@
+using OriginHairCollective.Newsletter.Application.Dtos;
+using OriginHairCollective.Newsletter.Application.Services;
+using OriginHairCollective.Newsletter.Core.Enums;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace OriginHairCollective.Newsletter.Api.Controllers;
+
+[ApiController]
+[Route("admin")]
+[Authorize(Roles = "Admin")]
+public sealed class AdminNewsletterController(INewsletterAdminService adminService) : ControllerBase
+{
+    [HttpGet("subscribers")]
+    public async Task<IActionResult> GetSubscribers(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 25,
+        [FromQuery] SubscriberStatus? status = null,
+        [FromQuery] string? tag = null,
+        CancellationToken ct = default)
+    {
+        var result = await adminService.GetSubscribersAsync(page, pageSize, status, tag, ct);
+        return Ok(result);
+    }
+
+    [HttpGet("subscribers/stats")]
+    public async Task<IActionResult> GetSubscriberStats(CancellationToken ct)
+    {
+        var result = await adminService.GetSubscriberStatsAsync(ct);
+        return Ok(result);
+    }
+
+    [HttpDelete("subscribers/{id:guid}")]
+    public async Task<IActionResult> DeleteSubscriber(Guid id, CancellationToken ct)
+    {
+        await adminService.DeleteSubscriberAsync(id, ct);
+        return NoContent();
+    }
+
+    [HttpGet("campaigns")]
+    public async Task<IActionResult> GetCampaigns(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10,
+        [FromQuery] CampaignStatus? status = null,
+        CancellationToken ct = default)
+    {
+        var result = await adminService.GetCampaignsAsync(page, pageSize, status, ct);
+        return Ok(result);
+    }
+
+    [HttpGet("campaigns/{id:guid}")]
+    public async Task<IActionResult> GetCampaign(Guid id, CancellationToken ct)
+    {
+        try
+        {
+            var result = await adminService.GetCampaignAsync(id, ct);
+            return Ok(result);
+        }
+        catch (InvalidOperationException)
+        {
+            return NotFound();
+        }
+    }
+
+    [HttpPost("campaigns")]
+    public async Task<IActionResult> CreateCampaign([FromBody] CreateCampaignDto dto, CancellationToken ct)
+    {
+        // Extract user ID from JWT claims
+        var userIdClaim = User.FindFirst("sub")?.Value ?? User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+        var userId = Guid.TryParse(userIdClaim, out var parsedId) ? parsedId : Guid.Empty;
+
+        var result = await adminService.CreateCampaignAsync(dto, userId, ct);
+        return CreatedAtAction(nameof(GetCampaign), new { id = result.Id }, result);
+    }
+
+    [HttpPut("campaigns/{id:guid}")]
+    public async Task<IActionResult> UpdateCampaign(Guid id, [FromBody] UpdateCampaignDto dto, CancellationToken ct)
+    {
+        try
+        {
+            var result = await adminService.UpdateCampaignAsync(id, dto, ct);
+            return Ok(result);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
+    [HttpPost("campaigns/{id:guid}/send")]
+    public async Task<IActionResult> SendCampaign(Guid id, CancellationToken ct)
+    {
+        try
+        {
+            var totalRecipients = await adminService.SendCampaignAsync(id, ct);
+            return Accepted(new { message = "Campaign queued for delivery.", totalRecipients });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
+    [HttpPost("campaigns/{id:guid}/cancel")]
+    public async Task<IActionResult> CancelCampaign(Guid id, CancellationToken ct)
+    {
+        try
+        {
+            await adminService.CancelCampaignAsync(id, ct);
+            return Ok(new { message = "Campaign cancelled." });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
+    [HttpGet("campaigns/{id:guid}/recipients")]
+    public async Task<IActionResult> GetCampaignRecipients(
+        Guid id,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 50,
+        [FromQuery] DeliveryStatus? status = null,
+        CancellationToken ct = default)
+    {
+        var result = await adminService.GetCampaignRecipientsAsync(id, page, pageSize, status, ct);
+        return Ok(result);
+    }
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Api/Controllers/SubscriptionController.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Api/Controllers/SubscriptionController.cs
@@ -1,0 +1,49 @@
+using OriginHairCollective.Newsletter.Application.Dtos;
+using OriginHairCollective.Newsletter.Application.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace OriginHairCollective.Newsletter.Api.Controllers;
+
+[ApiController]
+[Route("subscribe")]
+public sealed class SubscriptionController(INewsletterSubscriptionService subscriptionService) : ControllerBase
+{
+    [HttpPost]
+    public async Task<IActionResult> Subscribe([FromBody] SubscribeRequestDto dto, CancellationToken ct)
+    {
+        var result = await subscriptionService.SubscribeAsync(dto, ct);
+
+        if (result.Message == "You are already subscribed.")
+            return Ok(result);
+
+        return Accepted(result);
+    }
+
+    [HttpGet("/confirm")]
+    public async Task<IActionResult> Confirm([FromQuery] string token, CancellationToken ct)
+    {
+        try
+        {
+            await subscriptionService.ConfirmAsync(token, ct);
+            return Ok(new { message = "Your subscription has been confirmed." });
+        }
+        catch (InvalidOperationException)
+        {
+            return NotFound(new { message = "Invalid or expired confirmation token." });
+        }
+    }
+
+    [HttpGet("/unsubscribe")]
+    public async Task<IActionResult> Unsubscribe([FromQuery] string token, CancellationToken ct)
+    {
+        try
+        {
+            await subscriptionService.UnsubscribeAsync(token, ct);
+            return Ok(new { message = "You have been unsubscribed." });
+        }
+        catch (InvalidOperationException)
+        {
+            return NotFound(new { message = "Invalid unsubscribe token." });
+        }
+    }
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Api/Controllers/TrackingController.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Api/Controllers/TrackingController.cs
@@ -1,0 +1,36 @@
+using OriginHairCollective.Newsletter.Application.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace OriginHairCollective.Newsletter.Api.Controllers;
+
+[ApiController]
+[Route("track")]
+public sealed class TrackingController(ITrackingService trackingService) : ControllerBase
+{
+    // 1x1 transparent GIF
+    private static readonly byte[] TransparentGif =
+    [
+        0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00,
+        0x01, 0x00, 0x80, 0x00, 0x00, 0xFF, 0xFF, 0xFF,
+        0x00, 0x00, 0x00, 0x21, 0xF9, 0x04, 0x01, 0x00,
+        0x00, 0x00, 0x00, 0x2C, 0x00, 0x00, 0x00, 0x00,
+        0x01, 0x00, 0x01, 0x00, 0x00, 0x02, 0x02, 0x44,
+        0x01, 0x00, 0x3B
+    ];
+
+    [HttpGet("open")]
+    public async Task<IActionResult> TrackOpen(
+        [FromQuery] Guid cid, [FromQuery] Guid sid, CancellationToken ct)
+    {
+        await trackingService.RecordOpenAsync(cid, sid, ct);
+        return File(TransparentGif, "image/gif");
+    }
+
+    [HttpGet("click")]
+    public async Task<IActionResult> TrackClick(
+        [FromQuery] Guid cid, [FromQuery] Guid sid, [FromQuery] string url, CancellationToken ct)
+    {
+        var targetUrl = await trackingService.RecordClickAsync(cid, sid, url, ct);
+        return Redirect(targetUrl);
+    }
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Api/OriginHairCollective.Newsletter.Api.csproj
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Api/OriginHairCollective.Newsletter.Api.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="MassTransit.RabbitMQ" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OriginHairCollective.Newsletter.Application\OriginHairCollective.Newsletter.Application.csproj" />
+    <ProjectReference Include="..\OriginHairCollective.Newsletter.Infrastructure\OriginHairCollective.Newsletter.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Aspire\OriginHairCollective.ServiceDefaults\OriginHairCollective.ServiceDefaults.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Api/Program.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Api/Program.cs
@@ -1,0 +1,85 @@
+using OriginHairCollective.Newsletter.Api.BackgroundServices;
+using OriginHairCollective.Newsletter.Application.Consumers;
+using OriginHairCollective.Newsletter.Application.Email;
+using OriginHairCollective.Newsletter.Application.Services;
+using OriginHairCollective.Newsletter.Core.Interfaces;
+using OriginHairCollective.Newsletter.Infrastructure.Data;
+using OriginHairCollective.Newsletter.Infrastructure.Repositories;
+using OriginHairCollective.ServiceDefaults;
+using MassTransit;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.EntityFrameworkCore;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.AddServiceDefaults();
+
+builder.Services.AddControllers();
+builder.Services.AddOpenApi();
+
+// Database
+builder.Services.AddDbContext<NewsletterDbContext>(options =>
+    options.UseSqlite(builder.Configuration.GetConnectionString("NewsletterDb")
+        ?? "Data Source=newsletter.db"));
+
+// Repositories
+builder.Services.AddScoped<ISubscriberRepository, SubscriberRepository>();
+builder.Services.AddScoped<ICampaignRepository, CampaignRepository>();
+builder.Services.AddScoped<ICampaignRecipientRepository, CampaignRecipientRepository>();
+
+// Services
+builder.Services.AddScoped<INewsletterSubscriptionService, NewsletterSubscriptionService>();
+builder.Services.AddScoped<INewsletterAdminService, NewsletterAdminService>();
+builder.Services.AddScoped<ITrackingService, TrackingService>();
+
+// Email
+builder.Services.AddScoped<IEmailSender, SmtpEmailSender>();
+builder.Services.AddScoped<IEmailContentProcessor, EmailContentProcessor>();
+
+// Background Services
+builder.Services.AddHostedService<CampaignSchedulerService>();
+
+// MassTransit
+builder.Services.AddMassTransit(x =>
+{
+    x.AddConsumer<UserRegisteredNewsletterConsumer>();
+    x.AddConsumer<CampaignSendConsumer>();
+
+    x.UsingRabbitMq((context, cfg) =>
+    {
+        var connectionString = builder.Configuration.GetConnectionString("messaging");
+        if (!string.IsNullOrEmpty(connectionString))
+        {
+            cfg.Host(connectionString);
+        }
+
+        cfg.ConfigureEndpoints(context);
+    });
+});
+
+// Auth
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer();
+builder.Services.AddAuthorization();
+
+var app = builder.Build();
+
+// Ensure DB created
+using (var scope = app.Services.CreateScope())
+{
+    var context = scope.ServiceProvider.GetRequiredService<NewsletterDbContext>();
+    await NewsletterDbSeeder.SeedAsync(context);
+}
+
+app.MapDefaultEndpoints();
+
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+}
+
+app.UseAuthentication();
+app.UseAuthorization();
+app.MapControllers();
+
+app.Run();

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Api/Properties/launchSettings.json
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Api/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5800",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Api/appsettings.Development.json
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Api/appsettings.json
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Api/appsettings.json
@@ -1,0 +1,30 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "NewsletterDb": "Data Source=newsletter.db"
+  },
+  "Email": {
+    "Provider": "Smtp",
+    "Smtp": {
+      "Host": "localhost",
+      "Port": 1025,
+      "UseSsl": false,
+      "Username": "",
+      "Password": ""
+    },
+    "FromName": "Origin Hair Collective",
+    "FromEmail": "newsletter@originhair.com"
+  },
+  "Newsletter": {
+    "BaseUrl": "https://originhair.com",
+    "BatchSize": 50,
+    "BatchDelayMs": 1000,
+    "SchedulerIntervalMinutes": 1
+  }
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Consumers/CampaignSendConsumer.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Consumers/CampaignSendConsumer.cs
@@ -1,0 +1,116 @@
+using OriginHairCollective.Newsletter.Application.Email;
+using OriginHairCollective.Newsletter.Core.Enums;
+using OriginHairCollective.Newsletter.Core.Interfaces;
+using OriginHairCollective.Shared.Contracts;
+using MassTransit;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace OriginHairCollective.Newsletter.Application.Consumers;
+
+public sealed class CampaignSendConsumer(
+    ICampaignRepository campaignRepository,
+    ICampaignRecipientRepository recipientRepository,
+    ISubscriberRepository subscriberRepository,
+    IEmailSender emailSender,
+    IEmailContentProcessor contentProcessor,
+    IConfiguration configuration,
+    IPublishEndpoint publishEndpoint,
+    ILogger<CampaignSendConsumer> logger) : IConsumer<CampaignSendRequestedEvent>
+{
+    public async Task Consume(ConsumeContext<CampaignSendRequestedEvent> context)
+    {
+        var evt = context.Message;
+        var campaign = await campaignRepository.GetByIdAsync(evt.CampaignId);
+        if (campaign is null || campaign.Status != CampaignStatus.Sending)
+            return;
+
+        var batchSize = int.Parse(configuration["Newsletter:BatchSize"] ?? "50");
+        var batchDelayMs = int.Parse(configuration["Newsletter:BatchDelayMs"] ?? "1000");
+        var fromName = configuration["Email:FromName"] ?? "Origin Hair Collective";
+        var fromEmail = configuration["Email:FromEmail"] ?? "newsletter@originhair.com";
+
+        var totalSent = 0;
+        var totalFailed = 0;
+
+        logger.LogInformation("Starting campaign send for {CampaignId} with {TotalRecipients} recipients",
+            campaign.Id, campaign.TotalRecipients);
+
+        while (true)
+        {
+            var batch = await recipientRepository.GetQueuedByCampaignAsync(campaign.Id, batchSize);
+            if (batch.Count == 0)
+                break;
+
+            var messages = new List<EmailMessage>(batch.Count);
+
+            foreach (var recipient in batch)
+            {
+                var subscriber = await subscriberRepository.GetByIdAsync(recipient.SubscriberId);
+                var unsubscribeToken = subscriber?.UnsubscribeToken ?? "";
+
+                var processedHtml = contentProcessor.ProcessHtml(
+                    campaign.HtmlBody, campaign.Id, recipient.SubscriberId, unsubscribeToken);
+
+                var headers = new Dictionary<string, string>();
+                if (!string.IsNullOrEmpty(unsubscribeToken))
+                {
+                    var baseUrl = configuration["Newsletter:BaseUrl"] ?? "https://originhair.com";
+                    headers["List-Unsubscribe"] = $"<{baseUrl}/api/newsletters/unsubscribe?token={unsubscribeToken}>";
+                    headers["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click";
+                }
+
+                messages.Add(new EmailMessage(
+                    recipient.Email,
+                    campaign.Subject,
+                    processedHtml,
+                    campaign.PlainTextBody,
+                    fromName,
+                    fromEmail,
+                    headers));
+            }
+
+            var results = await emailSender.SendBatchAsync(messages);
+
+            for (var i = 0; i < batch.Count; i++)
+            {
+                var recipient = batch[i];
+                var result = results[i];
+
+                if (result.Success)
+                {
+                    recipient.Status = DeliveryStatus.Sent;
+                    recipient.SentAt = DateTime.UtcNow;
+                    totalSent++;
+                }
+                else
+                {
+                    recipient.Status = DeliveryStatus.Failed;
+                    recipient.ErrorMessage = result.ErrorMessage;
+                    totalFailed++;
+                }
+            }
+
+            await recipientRepository.UpdateBatchAsync(batch.ToList());
+
+            campaign.TotalSent = totalSent;
+            campaign.TotalBounced = totalFailed;
+            await campaignRepository.UpdateAsync(campaign);
+
+            if (batchDelayMs > 0)
+                await Task.Delay(batchDelayMs);
+        }
+
+        campaign.Status = CampaignStatus.Sent;
+        campaign.SentAt = DateTime.UtcNow;
+        campaign.TotalSent = totalSent;
+        campaign.TotalBounced = totalFailed;
+        await campaignRepository.UpdateAsync(campaign);
+
+        await publishEndpoint.Publish(new CampaignCompletedEvent(
+            campaign.Id, totalSent, totalFailed, DateTime.UtcNow));
+
+        logger.LogInformation("Campaign {CampaignId} completed. Sent: {Sent}, Failed: {Failed}",
+            campaign.Id, totalSent, totalFailed);
+    }
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Consumers/UserRegisteredNewsletterConsumer.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Consumers/UserRegisteredNewsletterConsumer.cs
@@ -1,0 +1,65 @@
+using OriginHairCollective.Newsletter.Core.Entities;
+using OriginHairCollective.Newsletter.Core.Enums;
+using OriginHairCollective.Newsletter.Core.Interfaces;
+using OriginHairCollective.Shared.Contracts;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+
+namespace OriginHairCollective.Newsletter.Application.Consumers;
+
+public sealed class UserRegisteredNewsletterConsumer(
+    ISubscriberRepository subscriberRepository,
+    ILogger<UserRegisteredNewsletterConsumer> logger) : IConsumer<UserRegisteredEvent>
+{
+    public async Task Consume(ConsumeContext<UserRegisteredEvent> context)
+    {
+        var evt = context.Message;
+
+        if (!evt.NewsletterOptIn)
+            return;
+
+        var normalizedEmail = evt.Email.Trim().ToLowerInvariant();
+        var existing = await subscriberRepository.GetByEmailAsync(normalizedEmail);
+
+        if (existing is not null)
+        {
+            if (existing.Status == SubscriberStatus.Active)
+            {
+                // Already subscribed; link UserId if not set
+                if (!existing.UserId.HasValue)
+                {
+                    existing.UserId = evt.UserId;
+                    await subscriberRepository.UpdateAsync(existing);
+                }
+                return;
+            }
+
+            // Reactivate
+            existing.Status = SubscriberStatus.Active;
+            existing.UserId = evt.UserId;
+            existing.ConfirmedAt = DateTime.UtcNow;
+            existing.ConfirmationToken = null;
+            existing.UnsubscribedAt = null;
+            await subscriberRepository.UpdateAsync(existing);
+
+            logger.LogInformation("Reactivated subscriber {Email} via user registration", normalizedEmail);
+            return;
+        }
+
+        var subscriber = new Subscriber
+        {
+            Id = Guid.NewGuid(),
+            Email = normalizedEmail,
+            FirstName = evt.FirstName,
+            LastName = evt.LastName,
+            UserId = evt.UserId,
+            Status = SubscriberStatus.Active,
+            ConfirmedAt = DateTime.UtcNow,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        await subscriberRepository.AddAsync(subscriber);
+
+        logger.LogInformation("Auto-subscribed {Email} via user registration", normalizedEmail);
+    }
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Dtos/CampaignDetailDto.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Dtos/CampaignDetailDto.cs
@@ -1,0 +1,20 @@
+namespace OriginHairCollective.Newsletter.Application.Dtos;
+
+public sealed record CampaignDetailDto(
+    Guid Id,
+    string Subject,
+    string HtmlBody,
+    string? PlainTextBody,
+    string Status,
+    string? TargetTag,
+    int TotalRecipients,
+    int TotalSent,
+    int TotalOpened,
+    int TotalClicked,
+    int TotalBounced,
+    int TotalUnsubscribed,
+    DateTime? ScheduledAt,
+    DateTime? SentAt,
+    Guid CreatedByUserId,
+    DateTime CreatedAt,
+    DateTime? UpdatedAt);

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Dtos/CampaignDto.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Dtos/CampaignDto.cs
@@ -1,0 +1,16 @@
+namespace OriginHairCollective.Newsletter.Application.Dtos;
+
+public sealed record CampaignDto(
+    Guid Id,
+    string Subject,
+    string Status,
+    string? TargetTag,
+    int TotalRecipients,
+    int TotalSent,
+    int TotalOpened,
+    int TotalClicked,
+    int TotalBounced,
+    int TotalUnsubscribed,
+    DateTime? ScheduledAt,
+    DateTime? SentAt,
+    DateTime CreatedAt);

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Dtos/CampaignRecipientDto.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Dtos/CampaignRecipientDto.cs
@@ -1,0 +1,10 @@
+namespace OriginHairCollective.Newsletter.Application.Dtos;
+
+public sealed record CampaignRecipientDto(
+    Guid Id,
+    string Email,
+    string Status,
+    DateTime? SentAt,
+    DateTime? OpenedAt,
+    DateTime? ClickedAt,
+    string? ErrorMessage);

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Dtos/CreateCampaignDto.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Dtos/CreateCampaignDto.cs
@@ -1,0 +1,8 @@
+namespace OriginHairCollective.Newsletter.Application.Dtos;
+
+public sealed record CreateCampaignDto(
+    string Subject,
+    string HtmlBody,
+    string? PlainTextBody,
+    string? TargetTag,
+    DateTime? ScheduledAt);

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Dtos/PagedResultDto.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Dtos/PagedResultDto.cs
@@ -1,0 +1,7 @@
+namespace OriginHairCollective.Newsletter.Application.Dtos;
+
+public sealed record PagedResultDto<T>(
+    IReadOnlyList<T> Items,
+    int TotalCount,
+    int Page,
+    int PageSize);

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Dtos/SubscribeRequestDto.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Dtos/SubscribeRequestDto.cs
@@ -1,0 +1,7 @@
+namespace OriginHairCollective.Newsletter.Application.Dtos;
+
+public sealed record SubscribeRequestDto(
+    string Email,
+    string? FirstName,
+    string? LastName,
+    List<string>? Tags);

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Dtos/SubscribeResponseDto.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Dtos/SubscribeResponseDto.cs
@@ -1,0 +1,3 @@
+namespace OriginHairCollective.Newsletter.Application.Dtos;
+
+public sealed record SubscribeResponseDto(string Message);

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Dtos/SubscriberDto.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Dtos/SubscriberDto.cs
@@ -1,0 +1,12 @@
+namespace OriginHairCollective.Newsletter.Application.Dtos;
+
+public sealed record SubscriberDto(
+    Guid Id,
+    string Email,
+    string? FirstName,
+    string? LastName,
+    string Status,
+    List<string> Tags,
+    DateTime? ConfirmedAt,
+    DateTime CreatedAt,
+    DateTime? UnsubscribedAt);

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Dtos/SubscriberStatsDto.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Dtos/SubscriberStatsDto.cs
@@ -1,0 +1,7 @@
+namespace OriginHairCollective.Newsletter.Application.Dtos;
+
+public sealed record SubscriberStatsDto(
+    int TotalActive,
+    int TotalPending,
+    int TotalUnsubscribed,
+    int RecentSubscribers);

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Dtos/UpdateCampaignDto.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Dtos/UpdateCampaignDto.cs
@@ -1,0 +1,8 @@
+namespace OriginHairCollective.Newsletter.Application.Dtos;
+
+public sealed record UpdateCampaignDto(
+    string? Subject,
+    string? HtmlBody,
+    string? PlainTextBody,
+    string? TargetTag,
+    DateTime? ScheduledAt);

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Email/EmailContentProcessor.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Email/EmailContentProcessor.cs
@@ -1,0 +1,41 @@
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Configuration;
+
+namespace OriginHairCollective.Newsletter.Application.Email;
+
+public sealed partial class EmailContentProcessor(IConfiguration configuration) : IEmailContentProcessor
+{
+    public string ProcessHtml(string htmlBody, Guid campaignId, Guid subscriberId, string unsubscribeToken)
+    {
+        var baseUrl = configuration["Newsletter:BaseUrl"] ?? "https://originhair.com";
+        var processed = htmlBody;
+
+        // Rewrite links for click tracking
+        processed = LinkRegex().Replace(processed, match =>
+        {
+            var originalUrl = match.Groups[1].Value;
+            var encodedUrl = Uri.EscapeDataString(originalUrl);
+            var trackingUrl = $"{baseUrl}/api/newsletters/track/click?cid={campaignId}&sid={subscriberId}&url={encodedUrl}";
+            return $"href=\"{trackingUrl}\"";
+        });
+
+        // Inject tracking pixel before closing </body> tag
+        var trackingPixel = $"<img src=\"{baseUrl}/api/newsletters/track/open?cid={campaignId}&sid={subscriberId}\" width=\"1\" height=\"1\" alt=\"\" style=\"display:none\" />";
+        var unsubscribeLink = $"{baseUrl}/api/newsletters/unsubscribe?token={unsubscribeToken}";
+        var footer = $"<div style=\"text-align:center;padding:20px;font-size:12px;color:#999;\"><a href=\"{unsubscribeLink}\" style=\"color:#999;\">Unsubscribe</a></div>";
+
+        if (processed.Contains("</body>", StringComparison.OrdinalIgnoreCase))
+        {
+            processed = processed.Replace("</body>", $"{footer}{trackingPixel}</body>", StringComparison.OrdinalIgnoreCase);
+        }
+        else
+        {
+            processed += footer + trackingPixel;
+        }
+
+        return processed;
+    }
+
+    [GeneratedRegex("href=\"(https?://[^\"]+)\"", RegexOptions.IgnoreCase)]
+    private static partial Regex LinkRegex();
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Email/EmailMessage.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Email/EmailMessage.cs
@@ -1,0 +1,10 @@
+namespace OriginHairCollective.Newsletter.Application.Email;
+
+public sealed record EmailMessage(
+    string To,
+    string Subject,
+    string HtmlBody,
+    string? PlainTextBody,
+    string FromName,
+    string FromEmail,
+    Dictionary<string, string>? Headers);

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Email/EmailSendResult.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Email/EmailSendResult.cs
@@ -1,0 +1,7 @@
+namespace OriginHairCollective.Newsletter.Application.Email;
+
+public sealed record EmailSendResult(
+    string Recipient,
+    bool Success,
+    string? ExternalMessageId,
+    string? ErrorMessage);

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Email/IEmailContentProcessor.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Email/IEmailContentProcessor.cs
@@ -1,0 +1,6 @@
+namespace OriginHairCollective.Newsletter.Application.Email;
+
+public interface IEmailContentProcessor
+{
+    string ProcessHtml(string htmlBody, Guid campaignId, Guid subscriberId, string unsubscribeToken);
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Email/IEmailSender.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Email/IEmailSender.cs
@@ -1,0 +1,8 @@
+namespace OriginHairCollective.Newsletter.Application.Email;
+
+public interface IEmailSender
+{
+    Task<EmailSendResult> SendAsync(EmailMessage message, CancellationToken ct = default);
+    Task<IReadOnlyList<EmailSendResult>> SendBatchAsync(
+        IReadOnlyList<EmailMessage> messages, CancellationToken ct = default);
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Email/SmtpEmailSender.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Email/SmtpEmailSender.cs
@@ -1,0 +1,105 @@
+using System.Net;
+using System.Net.Mail;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace OriginHairCollective.Newsletter.Application.Email;
+
+public sealed class SmtpEmailSender(IConfiguration configuration, ILogger<SmtpEmailSender> logger) : IEmailSender
+{
+    public async Task<EmailSendResult> SendAsync(EmailMessage message, CancellationToken ct = default)
+    {
+        try
+        {
+            using var client = CreateSmtpClient();
+            using var mailMessage = CreateMailMessage(message);
+            await client.SendMailAsync(mailMessage, ct);
+
+            logger.LogInformation("Email sent to {Recipient}", message.To);
+            return new EmailSendResult(message.To, true, null, null);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to send email to {Recipient}", message.To);
+            return new EmailSendResult(message.To, false, null, ex.Message);
+        }
+    }
+
+    public async Task<IReadOnlyList<EmailSendResult>> SendBatchAsync(
+        IReadOnlyList<EmailMessage> messages, CancellationToken ct = default)
+    {
+        var results = new List<EmailSendResult>(messages.Count);
+
+        using var client = CreateSmtpClient();
+
+        foreach (var message in messages)
+        {
+            if (ct.IsCancellationRequested)
+                break;
+
+            try
+            {
+                using var mailMessage = CreateMailMessage(message);
+                await client.SendMailAsync(mailMessage, ct);
+                results.Add(new EmailSendResult(message.To, true, null, null));
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to send email to {Recipient}", message.To);
+                results.Add(new EmailSendResult(message.To, false, null, ex.Message));
+            }
+        }
+
+        return results;
+    }
+
+    private SmtpClient CreateSmtpClient()
+    {
+        var host = configuration["Email:Smtp:Host"] ?? "localhost";
+        var port = int.Parse(configuration["Email:Smtp:Port"] ?? "1025");
+        var useSsl = bool.Parse(configuration["Email:Smtp:UseSsl"] ?? "false");
+        var username = configuration["Email:Smtp:Username"];
+        var password = configuration["Email:Smtp:Password"];
+
+        var client = new SmtpClient(host, port)
+        {
+            EnableSsl = useSsl
+        };
+
+        if (!string.IsNullOrEmpty(username) && !string.IsNullOrEmpty(password))
+        {
+            client.Credentials = new NetworkCredential(username, password);
+        }
+
+        return client;
+    }
+
+    private static MailMessage CreateMailMessage(EmailMessage message)
+    {
+        var mailMessage = new MailMessage
+        {
+            From = new MailAddress(message.FromEmail, message.FromName),
+            Subject = message.Subject,
+            Body = message.HtmlBody,
+            IsBodyHtml = true
+        };
+
+        mailMessage.To.Add(message.To);
+
+        if (!string.IsNullOrEmpty(message.PlainTextBody))
+        {
+            mailMessage.AlternateViews.Add(
+                AlternateView.CreateAlternateViewFromString(message.PlainTextBody, null, "text/plain"));
+        }
+
+        if (message.Headers is not null)
+        {
+            foreach (var header in message.Headers)
+            {
+                mailMessage.Headers.Add(header.Key, header.Value);
+            }
+        }
+
+        return mailMessage;
+    }
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Mapping/NewsletterMappingExtensions.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Mapping/NewsletterMappingExtensions.cs
@@ -1,0 +1,61 @@
+using OriginHairCollective.Newsletter.Application.Dtos;
+using OriginHairCollective.Newsletter.Core.Entities;
+
+namespace OriginHairCollective.Newsletter.Application.Mapping;
+
+public static class NewsletterMappingExtensions
+{
+    public static SubscriberDto ToDto(this Subscriber subscriber) =>
+        new(subscriber.Id,
+            subscriber.Email,
+            subscriber.FirstName,
+            subscriber.LastName,
+            subscriber.Status.ToString(),
+            subscriber.Tags.Select(t => t.Tag).ToList(),
+            subscriber.ConfirmedAt,
+            subscriber.CreatedAt,
+            subscriber.UnsubscribedAt);
+
+    public static CampaignDto ToDto(this Campaign campaign) =>
+        new(campaign.Id,
+            campaign.Subject,
+            campaign.Status.ToString(),
+            campaign.TargetTag,
+            campaign.TotalRecipients,
+            campaign.TotalSent,
+            campaign.TotalOpened,
+            campaign.TotalClicked,
+            campaign.TotalBounced,
+            campaign.TotalUnsubscribed,
+            campaign.ScheduledAt,
+            campaign.SentAt,
+            campaign.CreatedAt);
+
+    public static CampaignDetailDto ToDetailDto(this Campaign campaign) =>
+        new(campaign.Id,
+            campaign.Subject,
+            campaign.HtmlBody,
+            campaign.PlainTextBody,
+            campaign.Status.ToString(),
+            campaign.TargetTag,
+            campaign.TotalRecipients,
+            campaign.TotalSent,
+            campaign.TotalOpened,
+            campaign.TotalClicked,
+            campaign.TotalBounced,
+            campaign.TotalUnsubscribed,
+            campaign.ScheduledAt,
+            campaign.SentAt,
+            campaign.CreatedByUserId,
+            campaign.CreatedAt,
+            campaign.UpdatedAt);
+
+    public static CampaignRecipientDto ToDto(this CampaignRecipient recipient) =>
+        new(recipient.Id,
+            recipient.Email,
+            recipient.Status.ToString(),
+            recipient.SentAt,
+            recipient.OpenedAt,
+            recipient.ClickedAt,
+            recipient.ErrorMessage);
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/OriginHairCollective.Newsletter.Application.csproj
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/OriginHairCollective.Newsletter.Application.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MassTransit" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OriginHairCollective.Newsletter.Core\OriginHairCollective.Newsletter.Core.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Shared\OriginHairCollective.Shared.Contracts\OriginHairCollective.Shared.Contracts.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Services/INewsletterAdminService.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Services/INewsletterAdminService.cs
@@ -1,0 +1,21 @@
+using OriginHairCollective.Newsletter.Application.Dtos;
+using OriginHairCollective.Newsletter.Core.Enums;
+
+namespace OriginHairCollective.Newsletter.Application.Services;
+
+public interface INewsletterAdminService
+{
+    Task<PagedResultDto<SubscriberDto>> GetSubscribersAsync(
+        int page, int pageSize, SubscriberStatus? status, string? tag, CancellationToken ct = default);
+    Task<SubscriberStatsDto> GetSubscriberStatsAsync(CancellationToken ct = default);
+    Task DeleteSubscriberAsync(Guid id, CancellationToken ct = default);
+    Task<CampaignDetailDto> CreateCampaignAsync(CreateCampaignDto request, Guid userId, CancellationToken ct = default);
+    Task<CampaignDetailDto> UpdateCampaignAsync(Guid id, UpdateCampaignDto request, CancellationToken ct = default);
+    Task<PagedResultDto<CampaignDto>> GetCampaignsAsync(
+        int page, int pageSize, CampaignStatus? status, CancellationToken ct = default);
+    Task<CampaignDetailDto> GetCampaignAsync(Guid id, CancellationToken ct = default);
+    Task<int> SendCampaignAsync(Guid id, CancellationToken ct = default);
+    Task CancelCampaignAsync(Guid id, CancellationToken ct = default);
+    Task<PagedResultDto<CampaignRecipientDto>> GetCampaignRecipientsAsync(
+        Guid campaignId, int page, int pageSize, DeliveryStatus? status, CancellationToken ct = default);
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Services/INewsletterSubscriptionService.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Services/INewsletterSubscriptionService.cs
@@ -1,0 +1,10 @@
+using OriginHairCollective.Newsletter.Application.Dtos;
+
+namespace OriginHairCollective.Newsletter.Application.Services;
+
+public interface INewsletterSubscriptionService
+{
+    Task<SubscribeResponseDto> SubscribeAsync(SubscribeRequestDto request, CancellationToken ct = default);
+    Task ConfirmAsync(string token, CancellationToken ct = default);
+    Task UnsubscribeAsync(string token, CancellationToken ct = default);
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Services/ITrackingService.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Services/ITrackingService.cs
@@ -1,0 +1,7 @@
+namespace OriginHairCollective.Newsletter.Application.Services;
+
+public interface ITrackingService
+{
+    Task RecordOpenAsync(Guid campaignId, Guid subscriberId, CancellationToken ct = default);
+    Task<string> RecordClickAsync(Guid campaignId, Guid subscriberId, string targetUrl, CancellationToken ct = default);
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Services/NewsletterAdminService.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Services/NewsletterAdminService.cs
@@ -1,0 +1,149 @@
+using OriginHairCollective.Newsletter.Application.Dtos;
+using OriginHairCollective.Newsletter.Application.Mapping;
+using OriginHairCollective.Newsletter.Core.Entities;
+using OriginHairCollective.Newsletter.Core.Enums;
+using OriginHairCollective.Newsletter.Core.Interfaces;
+using OriginHairCollective.Shared.Contracts;
+using MassTransit;
+
+namespace OriginHairCollective.Newsletter.Application.Services;
+
+public sealed class NewsletterAdminService(
+    ISubscriberRepository subscriberRepository,
+    ICampaignRepository campaignRepository,
+    ICampaignRecipientRepository campaignRecipientRepository,
+    IPublishEndpoint publishEndpoint) : INewsletterAdminService
+{
+    public async Task<PagedResultDto<SubscriberDto>> GetSubscribersAsync(
+        int page, int pageSize, SubscriberStatus? status, string? tag, CancellationToken ct = default)
+    {
+        var (items, totalCount) = await subscriberRepository.GetPagedAsync(page, pageSize, status, tag, ct);
+        return new PagedResultDto<SubscriberDto>(
+            items.Select(s => s.ToDto()).ToList(),
+            totalCount, page, pageSize);
+    }
+
+    public async Task<SubscriberStatsDto> GetSubscriberStatsAsync(CancellationToken ct = default)
+    {
+        var (totalActive, totalPending, totalUnsubscribed, recentSubscribers) =
+            await subscriberRepository.GetStatsAsync(ct);
+        return new SubscriberStatsDto(totalActive, totalPending, totalUnsubscribed, recentSubscribers);
+    }
+
+    public async Task DeleteSubscriberAsync(Guid id, CancellationToken ct = default)
+    {
+        await subscriberRepository.DeleteAsync(id, ct);
+    }
+
+    public async Task<CampaignDetailDto> CreateCampaignAsync(CreateCampaignDto request, Guid userId, CancellationToken ct = default)
+    {
+        var campaign = new Campaign
+        {
+            Id = Guid.NewGuid(),
+            Subject = request.Subject,
+            HtmlBody = request.HtmlBody,
+            PlainTextBody = request.PlainTextBody,
+            Status = request.ScheduledAt.HasValue ? CampaignStatus.Scheduled : CampaignStatus.Draft,
+            ScheduledAt = request.ScheduledAt,
+            TargetTag = request.TargetTag,
+            CreatedByUserId = userId,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        await campaignRepository.AddAsync(campaign, ct);
+        return campaign.ToDetailDto();
+    }
+
+    public async Task<CampaignDetailDto> UpdateCampaignAsync(Guid id, UpdateCampaignDto request, CancellationToken ct = default)
+    {
+        var campaign = await campaignRepository.GetByIdAsync(id, ct)
+            ?? throw new InvalidOperationException("Campaign not found.");
+
+        if (campaign.Status is not (CampaignStatus.Draft or CampaignStatus.Scheduled))
+            throw new InvalidOperationException("Only draft or scheduled campaigns can be updated.");
+
+        if (request.Subject is not null) campaign.Subject = request.Subject;
+        if (request.HtmlBody is not null) campaign.HtmlBody = request.HtmlBody;
+        if (request.PlainTextBody is not null) campaign.PlainTextBody = request.PlainTextBody;
+        if (request.TargetTag is not null) campaign.TargetTag = request.TargetTag;
+        if (request.ScheduledAt.HasValue)
+        {
+            campaign.ScheduledAt = request.ScheduledAt;
+            campaign.Status = CampaignStatus.Scheduled;
+        }
+
+        campaign.UpdatedAt = DateTime.UtcNow;
+        await campaignRepository.UpdateAsync(campaign, ct);
+        return campaign.ToDetailDto();
+    }
+
+    public async Task<PagedResultDto<CampaignDto>> GetCampaignsAsync(
+        int page, int pageSize, CampaignStatus? status, CancellationToken ct = default)
+    {
+        var (items, totalCount) = await campaignRepository.GetPagedAsync(page, pageSize, status, ct);
+        return new PagedResultDto<CampaignDto>(
+            items.Select(c => c.ToDto()).ToList(),
+            totalCount, page, pageSize);
+    }
+
+    public async Task<CampaignDetailDto> GetCampaignAsync(Guid id, CancellationToken ct = default)
+    {
+        var campaign = await campaignRepository.GetByIdAsync(id, ct)
+            ?? throw new InvalidOperationException("Campaign not found.");
+        return campaign.ToDetailDto();
+    }
+
+    public async Task<int> SendCampaignAsync(Guid id, CancellationToken ct = default)
+    {
+        var campaign = await campaignRepository.GetByIdAsync(id, ct)
+            ?? throw new InvalidOperationException("Campaign not found.");
+
+        if (campaign.Status is not (CampaignStatus.Draft or CampaignStatus.Scheduled))
+            throw new InvalidOperationException("Only draft or scheduled campaigns can be sent.");
+
+        var subscribers = await subscriberRepository.GetActiveByTagAsync(campaign.TargetTag, ct);
+
+        var recipients = subscribers.Select(s => new CampaignRecipient
+        {
+            Id = Guid.NewGuid(),
+            CampaignId = campaign.Id,
+            SubscriberId = s.Id,
+            Email = s.Email,
+            Status = DeliveryStatus.Queued
+        }).ToList();
+
+        await campaignRecipientRepository.AddBatchAsync(recipients, ct);
+
+        campaign.Status = CampaignStatus.Sending;
+        campaign.TotalRecipients = recipients.Count;
+        await campaignRepository.UpdateAsync(campaign, ct);
+
+        await publishEndpoint.Publish(new CampaignSendRequestedEvent(
+            campaign.Id, campaign.Subject, recipients.Count, DateTime.UtcNow), ct);
+
+        return recipients.Count;
+    }
+
+    public async Task CancelCampaignAsync(Guid id, CancellationToken ct = default)
+    {
+        var campaign = await campaignRepository.GetByIdAsync(id, ct)
+            ?? throw new InvalidOperationException("Campaign not found.");
+
+        if (campaign.Status is not (CampaignStatus.Sending or CampaignStatus.Scheduled))
+            throw new InvalidOperationException("Only sending or scheduled campaigns can be cancelled.");
+
+        campaign.Status = CampaignStatus.Cancelled;
+        campaign.UpdatedAt = DateTime.UtcNow;
+        await campaignRepository.UpdateAsync(campaign, ct);
+    }
+
+    public async Task<PagedResultDto<CampaignRecipientDto>> GetCampaignRecipientsAsync(
+        Guid campaignId, int page, int pageSize, DeliveryStatus? status, CancellationToken ct = default)
+    {
+        var (items, totalCount) = await campaignRecipientRepository.GetPagedByCampaignAsync(
+            campaignId, page, pageSize, status, ct);
+        return new PagedResultDto<CampaignRecipientDto>(
+            items.Select(r => r.ToDto()).ToList(),
+            totalCount, page, pageSize);
+    }
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Services/NewsletterSubscriptionService.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Services/NewsletterSubscriptionService.cs
@@ -1,0 +1,130 @@
+using System.Security.Cryptography;
+using OriginHairCollective.Newsletter.Application.Dtos;
+using OriginHairCollective.Newsletter.Core.Entities;
+using OriginHairCollective.Newsletter.Core.Enums;
+using OriginHairCollective.Newsletter.Core.Interfaces;
+using OriginHairCollective.Shared.Contracts;
+using MassTransit;
+
+namespace OriginHairCollective.Newsletter.Application.Services;
+
+public sealed class NewsletterSubscriptionService(
+    ISubscriberRepository subscriberRepository,
+    IPublishEndpoint publishEndpoint) : INewsletterSubscriptionService
+{
+    public async Task<SubscribeResponseDto> SubscribeAsync(SubscribeRequestDto request, CancellationToken ct = default)
+    {
+        var normalizedEmail = request.Email.Trim().ToLowerInvariant();
+        var existing = await subscriberRepository.GetByEmailAsync(normalizedEmail, ct);
+
+        if (existing is not null && existing.Status == SubscriberStatus.Active)
+        {
+            return new SubscribeResponseDto("You are already subscribed.");
+        }
+
+        var confirmationToken = GenerateToken();
+
+        if (existing is not null)
+        {
+            // Re-subscribe: reset to Pending with a new token
+            existing.Status = SubscriberStatus.Pending;
+            existing.ConfirmationToken = confirmationToken;
+            existing.FirstName = request.FirstName ?? existing.FirstName;
+            existing.LastName = request.LastName ?? existing.LastName;
+            existing.UnsubscribedAt = null;
+
+            if (request.Tags is { Count: > 0 })
+            {
+                var existingTagNames = existing.Tags.Select(t => t.Tag).ToHashSet();
+                foreach (var tag in request.Tags.Where(t => !existingTagNames.Contains(t)))
+                {
+                    existing.Tags.Add(new SubscriberTag
+                    {
+                        Id = Guid.NewGuid(),
+                        SubscriberId = existing.Id,
+                        Tag = tag,
+                        CreatedAt = DateTime.UtcNow
+                    });
+                }
+            }
+
+            await subscriberRepository.UpdateAsync(existing, ct);
+
+            await publishEndpoint.Publish(new SubscriptionRequestedEvent(
+                existing.Id, normalizedEmail, existing.FirstName, confirmationToken, DateTime.UtcNow), ct);
+
+            return new SubscribeResponseDto("A confirmation email has been sent to your address.");
+        }
+
+        var subscriber = new Subscriber
+        {
+            Id = Guid.NewGuid(),
+            Email = normalizedEmail,
+            FirstName = request.FirstName,
+            LastName = request.LastName,
+            Status = SubscriberStatus.Pending,
+            ConfirmationToken = confirmationToken,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        if (request.Tags is { Count: > 0 })
+        {
+            foreach (var tag in request.Tags)
+            {
+                subscriber.Tags.Add(new SubscriberTag
+                {
+                    Id = Guid.NewGuid(),
+                    SubscriberId = subscriber.Id,
+                    Tag = tag,
+                    CreatedAt = DateTime.UtcNow
+                });
+            }
+        }
+
+        await subscriberRepository.AddAsync(subscriber, ct);
+
+        await publishEndpoint.Publish(new SubscriptionRequestedEvent(
+            subscriber.Id, normalizedEmail, subscriber.FirstName, confirmationToken, DateTime.UtcNow), ct);
+
+        return new SubscribeResponseDto("A confirmation email has been sent to your address.");
+    }
+
+    public async Task ConfirmAsync(string token, CancellationToken ct = default)
+    {
+        var subscriber = await subscriberRepository.GetByConfirmationTokenAsync(token, ct)
+            ?? throw new InvalidOperationException("Invalid or expired confirmation token.");
+
+        subscriber.Status = SubscriberStatus.Active;
+        subscriber.ConfirmedAt = DateTime.UtcNow;
+        subscriber.ConfirmationToken = null;
+        subscriber.UnsubscribeToken = GenerateToken();
+
+        await subscriberRepository.UpdateAsync(subscriber, ct);
+
+        await publishEndpoint.Publish(new SubscriberConfirmedEvent(
+            subscriber.Id, subscriber.Email, DateTime.UtcNow), ct);
+    }
+
+    public async Task UnsubscribeAsync(string token, CancellationToken ct = default)
+    {
+        var subscriber = await subscriberRepository.GetByUnsubscribeTokenAsync(token, ct)
+            ?? throw new InvalidOperationException("Invalid unsubscribe token.");
+
+        subscriber.Status = SubscriberStatus.Unsubscribed;
+        subscriber.UnsubscribedAt = DateTime.UtcNow;
+
+        await subscriberRepository.UpdateAsync(subscriber, ct);
+
+        await publishEndpoint.Publish(new SubscriberUnsubscribedEvent(
+            subscriber.Id, subscriber.Email, DateTime.UtcNow), ct);
+    }
+
+    private static string GenerateToken()
+    {
+        var bytes = RandomNumberGenerator.GetBytes(32);
+        return Convert.ToBase64String(bytes)
+            .Replace("+", "-")
+            .Replace("/", "_")
+            .TrimEnd('=');
+    }
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Services/TrackingService.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Application/Services/TrackingService.cs
@@ -1,0 +1,61 @@
+using OriginHairCollective.Newsletter.Core.Enums;
+using OriginHairCollective.Newsletter.Core.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace OriginHairCollective.Newsletter.Application.Services;
+
+public sealed class TrackingService(
+    ICampaignRecipientRepository recipientRepository,
+    ICampaignRepository campaignRepository,
+    ILogger<TrackingService> logger) : ITrackingService
+{
+    public async Task RecordOpenAsync(Guid campaignId, Guid subscriberId, CancellationToken ct = default)
+    {
+        var (recipients, _) = await recipientRepository.GetPagedByCampaignAsync(campaignId, 1, 1, null, ct);
+        var recipient = recipients.FirstOrDefault(r => r.SubscriberId == subscriberId);
+
+        if (recipient is null || recipient.OpenedAt.HasValue)
+            return;
+
+        recipient.OpenedAt = DateTime.UtcNow;
+        if (recipient.Status is DeliveryStatus.Sent or DeliveryStatus.Delivered)
+            recipient.Status = DeliveryStatus.Opened;
+
+        await recipientRepository.UpdateAsync(recipient, ct);
+
+        var campaign = await campaignRepository.GetByIdAsync(campaignId, ct);
+        if (campaign is not null)
+        {
+            campaign.TotalOpened++;
+            await campaignRepository.UpdateAsync(campaign, ct);
+        }
+
+        logger.LogInformation("Recorded open for campaign {CampaignId}, subscriber {SubscriberId}", campaignId, subscriberId);
+    }
+
+    public async Task<string> RecordClickAsync(Guid campaignId, Guid subscriberId, string targetUrl, CancellationToken ct = default)
+    {
+        var (recipients, _) = await recipientRepository.GetPagedByCampaignAsync(campaignId, 1, 1, null, ct);
+        var recipient = recipients.FirstOrDefault(r => r.SubscriberId == subscriberId);
+
+        if (recipient is not null && !recipient.ClickedAt.HasValue)
+        {
+            recipient.ClickedAt = DateTime.UtcNow;
+            if (recipient.Status is DeliveryStatus.Sent or DeliveryStatus.Delivered or DeliveryStatus.Opened)
+                recipient.Status = DeliveryStatus.Clicked;
+
+            await recipientRepository.UpdateAsync(recipient, ct);
+
+            var campaign = await campaignRepository.GetByIdAsync(campaignId, ct);
+            if (campaign is not null)
+            {
+                campaign.TotalClicked++;
+                await campaignRepository.UpdateAsync(campaign, ct);
+            }
+
+            logger.LogInformation("Recorded click for campaign {CampaignId}, subscriber {SubscriberId}", campaignId, subscriberId);
+        }
+
+        return targetUrl;
+    }
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Core/Entities/Campaign.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Core/Entities/Campaign.cs
@@ -1,0 +1,22 @@
+namespace OriginHairCollective.Newsletter.Core.Entities;
+
+public sealed class Campaign
+{
+    public Guid Id { get; set; }
+    public required string Subject { get; set; }
+    public required string HtmlBody { get; set; }
+    public string? PlainTextBody { get; set; }
+    public Enums.CampaignStatus Status { get; set; }
+    public DateTime? ScheduledAt { get; set; }
+    public DateTime? SentAt { get; set; }
+    public string? TargetTag { get; set; }
+    public int TotalRecipients { get; set; }
+    public int TotalSent { get; set; }
+    public int TotalOpened { get; set; }
+    public int TotalClicked { get; set; }
+    public int TotalBounced { get; set; }
+    public int TotalUnsubscribed { get; set; }
+    public Guid CreatedByUserId { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Core/Entities/CampaignRecipient.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Core/Entities/CampaignRecipient.cs
@@ -1,0 +1,14 @@
+namespace OriginHairCollective.Newsletter.Core.Entities;
+
+public sealed class CampaignRecipient
+{
+    public Guid Id { get; set; }
+    public Guid CampaignId { get; set; }
+    public Guid SubscriberId { get; set; }
+    public required string Email { get; set; }
+    public Enums.DeliveryStatus Status { get; set; }
+    public DateTime? SentAt { get; set; }
+    public DateTime? OpenedAt { get; set; }
+    public DateTime? ClickedAt { get; set; }
+    public string? ErrorMessage { get; set; }
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Core/Entities/Subscriber.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Core/Entities/Subscriber.cs
@@ -1,0 +1,17 @@
+namespace OriginHairCollective.Newsletter.Core.Entities;
+
+public sealed class Subscriber
+{
+    public Guid Id { get; set; }
+    public required string Email { get; set; }
+    public string? FirstName { get; set; }
+    public string? LastName { get; set; }
+    public Guid? UserId { get; set; }
+    public Enums.SubscriberStatus Status { get; set; }
+    public string? ConfirmationToken { get; set; }
+    public DateTime? ConfirmedAt { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime? UnsubscribedAt { get; set; }
+    public string? UnsubscribeToken { get; set; }
+    public ICollection<SubscriberTag> Tags { get; set; } = new List<SubscriberTag>();
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Core/Entities/SubscriberTag.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Core/Entities/SubscriberTag.cs
@@ -1,0 +1,9 @@
+namespace OriginHairCollective.Newsletter.Core.Entities;
+
+public sealed class SubscriberTag
+{
+    public Guid Id { get; set; }
+    public Guid SubscriberId { get; set; }
+    public required string Tag { get; set; }
+    public DateTime CreatedAt { get; set; }
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Core/Enums/CampaignStatus.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Core/Enums/CampaignStatus.cs
@@ -1,0 +1,10 @@
+namespace OriginHairCollective.Newsletter.Core.Enums;
+
+public enum CampaignStatus
+{
+    Draft,
+    Scheduled,
+    Sending,
+    Sent,
+    Cancelled
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Core/Enums/DeliveryStatus.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Core/Enums/DeliveryStatus.cs
@@ -1,0 +1,12 @@
+namespace OriginHairCollective.Newsletter.Core.Enums;
+
+public enum DeliveryStatus
+{
+    Queued,
+    Sent,
+    Delivered,
+    Opened,
+    Clicked,
+    Bounced,
+    Failed
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Core/Enums/SubscriberStatus.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Core/Enums/SubscriberStatus.cs
@@ -1,0 +1,8 @@
+namespace OriginHairCollective.Newsletter.Core.Enums;
+
+public enum SubscriberStatus
+{
+    Pending,
+    Active,
+    Unsubscribed
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Core/Interfaces/ICampaignRecipientRepository.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Core/Interfaces/ICampaignRecipientRepository.cs
@@ -1,0 +1,14 @@
+using OriginHairCollective.Newsletter.Core.Enums;
+
+namespace OriginHairCollective.Newsletter.Core.Interfaces;
+
+public interface ICampaignRecipientRepository
+{
+    Task AddBatchAsync(IReadOnlyList<Entities.CampaignRecipient> recipients, CancellationToken ct = default);
+    Task<(IReadOnlyList<Entities.CampaignRecipient> Items, int TotalCount)> GetPagedByCampaignAsync(
+        Guid campaignId, int page, int pageSize, DeliveryStatus? status, CancellationToken ct = default);
+    Task<IReadOnlyList<Entities.CampaignRecipient>> GetQueuedByCampaignAsync(
+        Guid campaignId, int batchSize, CancellationToken ct = default);
+    Task UpdateAsync(Entities.CampaignRecipient recipient, CancellationToken ct = default);
+    Task UpdateBatchAsync(IReadOnlyList<Entities.CampaignRecipient> recipients, CancellationToken ct = default);
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Core/Interfaces/ICampaignRepository.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Core/Interfaces/ICampaignRepository.cs
@@ -1,0 +1,13 @@
+using OriginHairCollective.Newsletter.Core.Enums;
+
+namespace OriginHairCollective.Newsletter.Core.Interfaces;
+
+public interface ICampaignRepository
+{
+    Task<Entities.Campaign?> GetByIdAsync(Guid id, CancellationToken ct = default);
+    Task<(IReadOnlyList<Entities.Campaign> Items, int TotalCount)> GetPagedAsync(
+        int page, int pageSize, CampaignStatus? status, CancellationToken ct = default);
+    Task<IReadOnlyList<Entities.Campaign>> GetScheduledDueAsync(DateTime asOf, CancellationToken ct = default);
+    Task AddAsync(Entities.Campaign campaign, CancellationToken ct = default);
+    Task UpdateAsync(Entities.Campaign campaign, CancellationToken ct = default);
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Core/Interfaces/ISubscriberRepository.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Core/Interfaces/ISubscriberRepository.cs
@@ -1,0 +1,18 @@
+using OriginHairCollective.Newsletter.Core.Enums;
+
+namespace OriginHairCollective.Newsletter.Core.Interfaces;
+
+public interface ISubscriberRepository
+{
+    Task<Entities.Subscriber?> GetByIdAsync(Guid id, CancellationToken ct = default);
+    Task<Entities.Subscriber?> GetByEmailAsync(string email, CancellationToken ct = default);
+    Task<Entities.Subscriber?> GetByConfirmationTokenAsync(string token, CancellationToken ct = default);
+    Task<Entities.Subscriber?> GetByUnsubscribeTokenAsync(string token, CancellationToken ct = default);
+    Task<(IReadOnlyList<Entities.Subscriber> Items, int TotalCount)> GetPagedAsync(
+        int page, int pageSize, SubscriberStatus? status, string? tag, CancellationToken ct = default);
+    Task<IReadOnlyList<Entities.Subscriber>> GetActiveByTagAsync(string? tag, CancellationToken ct = default);
+    Task<(int TotalActive, int TotalPending, int TotalUnsubscribed, int RecentSubscribers)> GetStatsAsync(CancellationToken ct = default);
+    Task AddAsync(Entities.Subscriber subscriber, CancellationToken ct = default);
+    Task UpdateAsync(Entities.Subscriber subscriber, CancellationToken ct = default);
+    Task DeleteAsync(Guid id, CancellationToken ct = default);
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Core/OriginHairCollective.Newsletter.Core.csproj
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Core/OriginHairCollective.Newsletter.Core.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+
+</Project>

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Infrastructure/Data/NewsletterDbContext.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Infrastructure/Data/NewsletterDbContext.cs
@@ -1,0 +1,53 @@
+using OriginHairCollective.Newsletter.Core.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace OriginHairCollective.Newsletter.Infrastructure.Data;
+
+public sealed class NewsletterDbContext(DbContextOptions<NewsletterDbContext> options) : DbContext(options)
+{
+    public DbSet<Subscriber> Subscribers => Set<Subscriber>();
+    public DbSet<SubscriberTag> SubscriberTags => Set<SubscriberTag>();
+    public DbSet<Campaign> Campaigns => Set<Campaign>();
+    public DbSet<CampaignRecipient> CampaignRecipients => Set<CampaignRecipient>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Subscriber>(e =>
+        {
+            e.HasKey(s => s.Id);
+            e.Property(s => s.Email).HasMaxLength(300).IsRequired();
+            e.HasIndex(s => s.Email).IsUnique();
+            e.Property(s => s.FirstName).HasMaxLength(200);
+            e.Property(s => s.LastName).HasMaxLength(200);
+            e.HasIndex(s => s.UserId);
+            e.Property(s => s.ConfirmationToken).HasMaxLength(100);
+            e.Property(s => s.UnsubscribeToken).HasMaxLength(100);
+            e.HasIndex(s => s.UnsubscribeToken).IsUnique().HasFilter("UnsubscribeToken IS NOT NULL");
+            e.HasMany(s => s.Tags).WithOne().HasForeignKey(t => t.SubscriberId).OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<SubscriberTag>(e =>
+        {
+            e.HasKey(t => t.Id);
+            e.Property(t => t.Tag).HasMaxLength(100).IsRequired();
+            e.HasIndex(t => t.SubscriberId);
+            e.HasIndex(t => new { t.SubscriberId, t.Tag }).IsUnique();
+        });
+
+        modelBuilder.Entity<Campaign>(e =>
+        {
+            e.HasKey(c => c.Id);
+            e.Property(c => c.Subject).HasMaxLength(500).IsRequired();
+            e.Property(c => c.HtmlBody).IsRequired();
+            e.Property(c => c.TargetTag).HasMaxLength(100);
+        });
+
+        modelBuilder.Entity<CampaignRecipient>(e =>
+        {
+            e.HasKey(r => r.Id);
+            e.Property(r => r.Email).HasMaxLength(300).IsRequired();
+            e.HasIndex(r => r.CampaignId);
+            e.HasIndex(r => new { r.CampaignId, r.SubscriberId }).IsUnique();
+        });
+    }
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Infrastructure/Data/NewsletterDbSeeder.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Infrastructure/Data/NewsletterDbSeeder.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace OriginHairCollective.Newsletter.Infrastructure.Data;
+
+public static class NewsletterDbSeeder
+{
+    public static async Task SeedAsync(NewsletterDbContext context)
+    {
+        await context.Database.EnsureCreatedAsync();
+
+        if (await context.Subscribers.AnyAsync())
+            return;
+
+        // No seed data required — subscribers and campaigns are created at runtime.
+    }
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Infrastructure/OriginHairCollective.Newsletter.Infrastructure.csproj
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Infrastructure/OriginHairCollective.Newsletter.Infrastructure.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OriginHairCollective.Newsletter.Core\OriginHairCollective.Newsletter.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Infrastructure/Repositories/CampaignRecipientRepository.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Infrastructure/Repositories/CampaignRecipientRepository.cs
@@ -1,0 +1,56 @@
+using OriginHairCollective.Newsletter.Core.Entities;
+using OriginHairCollective.Newsletter.Core.Enums;
+using OriginHairCollective.Newsletter.Core.Interfaces;
+using OriginHairCollective.Newsletter.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace OriginHairCollective.Newsletter.Infrastructure.Repositories;
+
+public sealed class CampaignRecipientRepository(NewsletterDbContext context) : ICampaignRecipientRepository
+{
+    public async Task AddBatchAsync(IReadOnlyList<CampaignRecipient> recipients, CancellationToken ct = default)
+    {
+        context.CampaignRecipients.AddRange(recipients);
+        await context.SaveChangesAsync(ct);
+    }
+
+    public async Task<(IReadOnlyList<CampaignRecipient> Items, int TotalCount)> GetPagedByCampaignAsync(
+        Guid campaignId, int page, int pageSize, DeliveryStatus? status, CancellationToken ct = default)
+    {
+        var query = context.CampaignRecipients
+            .Where(r => r.CampaignId == campaignId);
+
+        if (status.HasValue)
+            query = query.Where(r => r.Status == status.Value);
+
+        var totalCount = await query.CountAsync(ct);
+        var items = await query
+            .OrderBy(r => r.Email)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(ct);
+
+        return (items, totalCount);
+    }
+
+    public async Task<IReadOnlyList<CampaignRecipient>> GetQueuedByCampaignAsync(
+        Guid campaignId, int batchSize, CancellationToken ct = default)
+    {
+        return await context.CampaignRecipients
+            .Where(r => r.CampaignId == campaignId && r.Status == DeliveryStatus.Queued)
+            .Take(batchSize)
+            .ToListAsync(ct);
+    }
+
+    public async Task UpdateAsync(CampaignRecipient recipient, CancellationToken ct = default)
+    {
+        context.CampaignRecipients.Update(recipient);
+        await context.SaveChangesAsync(ct);
+    }
+
+    public async Task UpdateBatchAsync(IReadOnlyList<CampaignRecipient> recipients, CancellationToken ct = default)
+    {
+        context.CampaignRecipients.UpdateRange(recipients);
+        await context.SaveChangesAsync(ct);
+    }
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Infrastructure/Repositories/CampaignRepository.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Infrastructure/Repositories/CampaignRepository.cs
@@ -1,0 +1,52 @@
+using OriginHairCollective.Newsletter.Core.Entities;
+using OriginHairCollective.Newsletter.Core.Enums;
+using OriginHairCollective.Newsletter.Core.Interfaces;
+using OriginHairCollective.Newsletter.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace OriginHairCollective.Newsletter.Infrastructure.Repositories;
+
+public sealed class CampaignRepository(NewsletterDbContext context) : ICampaignRepository
+{
+    public async Task<Campaign?> GetByIdAsync(Guid id, CancellationToken ct = default)
+    {
+        return await context.Campaigns.FindAsync([id], ct);
+    }
+
+    public async Task<(IReadOnlyList<Campaign> Items, int TotalCount)> GetPagedAsync(
+        int page, int pageSize, CampaignStatus? status, CancellationToken ct = default)
+    {
+        var query = context.Campaigns.AsQueryable();
+
+        if (status.HasValue)
+            query = query.Where(c => c.Status == status.Value);
+
+        var totalCount = await query.CountAsync(ct);
+        var items = await query
+            .OrderByDescending(c => c.CreatedAt)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(ct);
+
+        return (items, totalCount);
+    }
+
+    public async Task<IReadOnlyList<Campaign>> GetScheduledDueAsync(DateTime asOf, CancellationToken ct = default)
+    {
+        return await context.Campaigns
+            .Where(c => c.Status == CampaignStatus.Scheduled && c.ScheduledAt <= asOf)
+            .ToListAsync(ct);
+    }
+
+    public async Task AddAsync(Campaign campaign, CancellationToken ct = default)
+    {
+        context.Campaigns.Add(campaign);
+        await context.SaveChangesAsync(ct);
+    }
+
+    public async Task UpdateAsync(Campaign campaign, CancellationToken ct = default)
+    {
+        context.Campaigns.Update(campaign);
+        await context.SaveChangesAsync(ct);
+    }
+}

--- a/src/Services/Newsletter/OriginHairCollective.Newsletter.Infrastructure/Repositories/SubscriberRepository.cs
+++ b/src/Services/Newsletter/OriginHairCollective.Newsletter.Infrastructure/Repositories/SubscriberRepository.cs
@@ -1,0 +1,106 @@
+using OriginHairCollective.Newsletter.Core.Entities;
+using OriginHairCollective.Newsletter.Core.Enums;
+using OriginHairCollective.Newsletter.Core.Interfaces;
+using OriginHairCollective.Newsletter.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace OriginHairCollective.Newsletter.Infrastructure.Repositories;
+
+public sealed class SubscriberRepository(NewsletterDbContext context) : ISubscriberRepository
+{
+    public async Task<Subscriber?> GetByIdAsync(Guid id, CancellationToken ct = default)
+    {
+        return await context.Subscribers
+            .Include(s => s.Tags)
+            .FirstOrDefaultAsync(s => s.Id == id, ct);
+    }
+
+    public async Task<Subscriber?> GetByEmailAsync(string email, CancellationToken ct = default)
+    {
+        return await context.Subscribers
+            .Include(s => s.Tags)
+            .FirstOrDefaultAsync(s => s.Email == email, ct);
+    }
+
+    public async Task<Subscriber?> GetByConfirmationTokenAsync(string token, CancellationToken ct = default)
+    {
+        return await context.Subscribers
+            .Include(s => s.Tags)
+            .FirstOrDefaultAsync(s => s.ConfirmationToken == token, ct);
+    }
+
+    public async Task<Subscriber?> GetByUnsubscribeTokenAsync(string token, CancellationToken ct = default)
+    {
+        return await context.Subscribers
+            .Include(s => s.Tags)
+            .FirstOrDefaultAsync(s => s.UnsubscribeToken == token, ct);
+    }
+
+    public async Task<(IReadOnlyList<Subscriber> Items, int TotalCount)> GetPagedAsync(
+        int page, int pageSize, SubscriberStatus? status, string? tag, CancellationToken ct = default)
+    {
+        var query = context.Subscribers.Include(s => s.Tags).AsQueryable();
+
+        if (status.HasValue)
+            query = query.Where(s => s.Status == status.Value);
+
+        if (!string.IsNullOrEmpty(tag))
+            query = query.Where(s => s.Tags.Any(t => t.Tag == tag));
+
+        var totalCount = await query.CountAsync(ct);
+        var items = await query
+            .OrderByDescending(s => s.CreatedAt)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(ct);
+
+        return (items, totalCount);
+    }
+
+    public async Task<IReadOnlyList<Subscriber>> GetActiveByTagAsync(string? tag, CancellationToken ct = default)
+    {
+        var query = context.Subscribers
+            .Where(s => s.Status == SubscriberStatus.Active);
+
+        if (!string.IsNullOrEmpty(tag))
+            query = query.Where(s => s.Tags.Any(t => t.Tag == tag));
+
+        return await query.ToListAsync(ct);
+    }
+
+    public async Task<(int TotalActive, int TotalPending, int TotalUnsubscribed, int RecentSubscribers)> GetStatsAsync(
+        CancellationToken ct = default)
+    {
+        var thirtyDaysAgo = DateTime.UtcNow.AddDays(-30);
+
+        var totalActive = await context.Subscribers.CountAsync(s => s.Status == SubscriberStatus.Active, ct);
+        var totalPending = await context.Subscribers.CountAsync(s => s.Status == SubscriberStatus.Pending, ct);
+        var totalUnsubscribed = await context.Subscribers.CountAsync(s => s.Status == SubscriberStatus.Unsubscribed, ct);
+        var recentSubscribers = await context.Subscribers.CountAsync(
+            s => s.Status == SubscriberStatus.Active && s.ConfirmedAt >= thirtyDaysAgo, ct);
+
+        return (totalActive, totalPending, totalUnsubscribed, recentSubscribers);
+    }
+
+    public async Task AddAsync(Subscriber subscriber, CancellationToken ct = default)
+    {
+        context.Subscribers.Add(subscriber);
+        await context.SaveChangesAsync(ct);
+    }
+
+    public async Task UpdateAsync(Subscriber subscriber, CancellationToken ct = default)
+    {
+        context.Subscribers.Update(subscriber);
+        await context.SaveChangesAsync(ct);
+    }
+
+    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
+    {
+        var subscriber = await context.Subscribers.FindAsync([id], ct);
+        if (subscriber is not null)
+        {
+            context.Subscribers.Remove(subscriber);
+            await context.SaveChangesAsync(ct);
+        }
+    }
+}

--- a/src/Services/Notification/OriginHairCollective.Notification.Api/Program.cs
+++ b/src/Services/Notification/OriginHairCollective.Notification.Api/Program.cs
@@ -29,6 +29,8 @@ builder.Services.AddMassTransit(x =>
     x.AddConsumer<RefundIssuedNotificationConsumer>();
     x.AddConsumer<InquiryReceivedNotificationConsumer>();
     x.AddConsumer<ChatConversationStartedNotificationConsumer>();
+    x.AddConsumer<SubscriptionConfirmationConsumer>();
+    x.AddConsumer<CampaignCompletedNotificationConsumer>();
 
     x.UsingRabbitMq((context, cfg) =>
     {

--- a/src/Services/Notification/OriginHairCollective.Notification.Application/Consumers/CampaignCompletedNotificationConsumer.cs
+++ b/src/Services/Notification/OriginHairCollective.Notification.Application/Consumers/CampaignCompletedNotificationConsumer.cs
@@ -1,0 +1,36 @@
+using OriginHairCollective.Notification.Core.Entities;
+using OriginHairCollective.Notification.Core.Enums;
+using OriginHairCollective.Notification.Core.Interfaces;
+using OriginHairCollective.Shared.Contracts;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+
+namespace OriginHairCollective.Notification.Application.Consumers;
+
+public sealed class CampaignCompletedNotificationConsumer(
+    INotificationLogRepository repository,
+    ILogger<CampaignCompletedNotificationConsumer> logger) : IConsumer<CampaignCompletedEvent>
+{
+    public async Task Consume(ConsumeContext<CampaignCompletedEvent> context)
+    {
+        var evt = context.Message;
+
+        logger.LogInformation("Campaign {CampaignId} completed. Sent: {TotalSent}, Failed: {TotalFailed}",
+            evt.CampaignId, evt.TotalSent, evt.TotalFailed);
+
+        var log = new NotificationLog
+        {
+            Id = Guid.NewGuid(),
+            Recipient = "system",
+            Subject = $"Campaign Completed — {evt.TotalSent} sent, {evt.TotalFailed} failed",
+            Type = NotificationType.NewsletterCampaign,
+            Channel = NotificationChannel.System,
+            ReferenceId = evt.CampaignId,
+            IsSent = true,
+            CreatedAt = DateTime.UtcNow,
+            SentAt = DateTime.UtcNow
+        };
+
+        await repository.AddAsync(log);
+    }
+}

--- a/src/Services/Notification/OriginHairCollective.Notification.Application/Consumers/SubscriptionConfirmationConsumer.cs
+++ b/src/Services/Notification/OriginHairCollective.Notification.Application/Consumers/SubscriptionConfirmationConsumer.cs
@@ -1,0 +1,35 @@
+using OriginHairCollective.Notification.Core.Entities;
+using OriginHairCollective.Notification.Core.Enums;
+using OriginHairCollective.Notification.Core.Interfaces;
+using OriginHairCollective.Shared.Contracts;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+
+namespace OriginHairCollective.Notification.Application.Consumers;
+
+public sealed class SubscriptionConfirmationConsumer(
+    INotificationLogRepository repository,
+    ILogger<SubscriptionConfirmationConsumer> logger) : IConsumer<SubscriptionRequestedEvent>
+{
+    public async Task Consume(ConsumeContext<SubscriptionRequestedEvent> context)
+    {
+        var evt = context.Message;
+
+        logger.LogInformation("Sending newsletter confirmation email to {Email}", evt.Email);
+
+        var log = new NotificationLog
+        {
+            Id = Guid.NewGuid(),
+            Recipient = evt.Email,
+            Subject = "Confirm Your Subscription — Origin Hair Collective",
+            Type = NotificationType.NewsletterConfirmation,
+            Channel = NotificationChannel.Email,
+            ReferenceId = evt.SubscriberId,
+            IsSent = true,
+            CreatedAt = DateTime.UtcNow,
+            SentAt = DateTime.UtcNow
+        };
+
+        await repository.AddAsync(log);
+    }
+}

--- a/src/Services/Notification/OriginHairCollective.Notification.Core/Enums/NotificationType.cs
+++ b/src/Services/Notification/OriginHairCollective.Notification.Core/Enums/NotificationType.cs
@@ -9,5 +9,7 @@ public enum NotificationType
     RefundConfirmation,
     InquiryAcknowledgment,
     WholesaleFollowUp,
-    ChatConversationStarted
+    ChatConversationStarted,
+    NewsletterConfirmation,
+    NewsletterCampaign
 }

--- a/src/Shared/OriginHairCollective.Shared.Contracts/CampaignCompletedEvent.cs
+++ b/src/Shared/OriginHairCollective.Shared.Contracts/CampaignCompletedEvent.cs
@@ -1,0 +1,7 @@
+namespace OriginHairCollective.Shared.Contracts;
+
+public sealed record CampaignCompletedEvent(
+    Guid CampaignId,
+    int TotalSent,
+    int TotalFailed,
+    DateTime OccurredAt);

--- a/src/Shared/OriginHairCollective.Shared.Contracts/CampaignSendRequestedEvent.cs
+++ b/src/Shared/OriginHairCollective.Shared.Contracts/CampaignSendRequestedEvent.cs
@@ -1,0 +1,7 @@
+namespace OriginHairCollective.Shared.Contracts;
+
+public sealed record CampaignSendRequestedEvent(
+    Guid CampaignId,
+    string Subject,
+    int TotalRecipients,
+    DateTime OccurredAt);

--- a/src/Shared/OriginHairCollective.Shared.Contracts/SubscriberConfirmedEvent.cs
+++ b/src/Shared/OriginHairCollective.Shared.Contracts/SubscriberConfirmedEvent.cs
@@ -1,0 +1,6 @@
+namespace OriginHairCollective.Shared.Contracts;
+
+public sealed record SubscriberConfirmedEvent(
+    Guid SubscriberId,
+    string Email,
+    DateTime OccurredAt);

--- a/src/Shared/OriginHairCollective.Shared.Contracts/SubscriberUnsubscribedEvent.cs
+++ b/src/Shared/OriginHairCollective.Shared.Contracts/SubscriberUnsubscribedEvent.cs
@@ -1,0 +1,6 @@
+namespace OriginHairCollective.Shared.Contracts;
+
+public sealed record SubscriberUnsubscribedEvent(
+    Guid SubscriberId,
+    string Email,
+    DateTime OccurredAt);

--- a/src/Shared/OriginHairCollective.Shared.Contracts/SubscriptionRequestedEvent.cs
+++ b/src/Shared/OriginHairCollective.Shared.Contracts/SubscriptionRequestedEvent.cs
@@ -1,0 +1,8 @@
+namespace OriginHairCollective.Shared.Contracts;
+
+public sealed record SubscriptionRequestedEvent(
+    Guid SubscriberId,
+    string Email,
+    string? FirstName,
+    string ConfirmationToken,
+    DateTime OccurredAt);

--- a/src/Shared/OriginHairCollective.Shared.Contracts/UserRegisteredEvent.cs
+++ b/src/Shared/OriginHairCollective.Shared.Contracts/UserRegisteredEvent.cs
@@ -1,0 +1,9 @@
+namespace OriginHairCollective.Shared.Contracts;
+
+public sealed record UserRegisteredEvent(
+    Guid UserId,
+    string Email,
+    string FirstName,
+    string LastName,
+    bool NewsletterOptIn,
+    DateTime OccurredAt);


### PR DESCRIPTION
Implements the full Newsletter service with four-layer architecture:

- Core: Subscriber, SubscriberTag, Campaign, CampaignRecipient entities
  with SubscriberStatus, CampaignStatus, DeliveryStatus enums and
  repository interfaces
- Infrastructure: EF Core SQLite DbContext with proper indexes/constraints,
  SubscriberRepository, CampaignRepository, CampaignRecipientRepository
- Application: DTOs, subscription/admin/tracking services, SMTP email sender,
  email content processor (tracking pixel, link rewriting, unsubscribe),
  MassTransit consumers (UserRegisteredNewsletterConsumer, CampaignSendConsumer)
- Api: Public endpoints (subscribe, confirm, unsubscribe, tracking),
  admin endpoints (subscribers CRUD, campaigns CRUD, send/cancel),
  CampaignSchedulerService background service, JWT auth for admin routes

Cross-service changes:
- Shared.Contracts: 6 new event records (SubscriptionRequested,
  SubscriberConfirmed, SubscriberUnsubscribed, CampaignSendRequested,
  CampaignCompleted, UserRegistered)
- Notification service: Added NewsletterConfirmation/NewsletterCampaign
  enum values and SubscriptionConfirmation/CampaignCompleted consumers
- API Gateway: Added newsletters route and cluster
- Aspire AppHost: Added newsletter-api project with messaging reference
- Solution: Added Newsletter projects under Services/Newsletter folder

https://claude.ai/code/session_012hh4Tshh4exy5BpTDBkKz6